### PR TITLE
Fix implicit declaration of function of strptime warning

### DIFF
--- a/datefmt.go
+++ b/datefmt.go
@@ -5,6 +5,7 @@ package datefmt
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#define __USE_XOPEN
 #include <time.h>
 
 void ptime(const char* src, const char* fmt, struct tm* tm) {


### PR DESCRIPTION
```
$ go install -v github.com/jeffjen/datefmt
github.com/jeffjen/datefmt
# github.com/jeffjen/datefmt
src/github.com/jeffjen/datefmt/datefmt.go: In function ‘ptime’:
src/github.com/jeffjen/datefmt/datefmt.go:11:2: warning: implicit declaration of function ‘strptime’ [-Wimplicit-function-declaration]
  strptime(src, fmt, tm);
  ^~~~~~~~
```